### PR TITLE
Fix empty banner object

### DIFF
--- a/app/models.ts
+++ b/app/models.ts
@@ -105,6 +105,7 @@ export class Installer {
         createdOn,
         status: DatabaseRecordStatus.Active,
       })
+
       const storeData = {
         name: store.name,
         logo: '',
@@ -112,6 +113,7 @@ export class Installer {
         phone: '',
         baseCurrencyId: 1, //Default to USD
         description: store.description,
+        banners: { autoplay: false, speed: 0, items: [] },
         other: {
           copyright: `${store.name} ©${new Date().getFullYear()}`,
           apis: {},

--- a/app/themes/default/components/ui/breadcrumb.tsx
+++ b/app/themes/default/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "app/themes/lib/utils"
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = "Breadcrumb"
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+))
+BreadcrumbList.displayName = "BreadcrumbList"
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+))
+BreadcrumbItem.displayName = "BreadcrumbItem"
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = "BreadcrumbLink"
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+))
+BreadcrumbPage.displayName = "BreadcrumbPage"
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:size-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+)
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/app/themes/default/components/ui/storefront/Header.tsx
+++ b/app/themes/default/components/ui/storefront/Header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { Link } from '@remix-run/react'
 import { Menu, ShoppingCart, UserRound } from 'lucide-react'
-import { useContext, useState } from 'react'
+import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import StoreContext from '~/contexts/storeContext'
 import {
@@ -29,8 +29,6 @@ const Header = ({
 }) => {
   const { t } = useTranslation()
   const { storeSettings, categories } = useContext(StoreContext)
-  const [subOpen, setSubOpen] = useState(false)
-  const [subCategories, setSubCategories] = useState([])
   const subtotal =
     cartItems && cartItems.length
       ? cartItems.reduce(

--- a/app/themes/default/components/ui/storefront/ProductCard.tsx
+++ b/app/themes/default/components/ui/storefront/ProductCard.tsx
@@ -38,7 +38,12 @@ const ProductCard = ({
           <p className="mt-3 text-lg">{price}</p>
         </CardFooter>
       </Link>
-      <Button variant="secondary" className="w-full" onClick={onClick}>
+      <Button
+        variant="secondary"
+        className="w-full"
+        onClick={onClick}
+        data-testid={id}
+      >
         {t('system.add_cart')}
       </Button>
     </Card>

--- a/app/themes/default/pages/storefront/tests/Home.test.tsx
+++ b/app/themes/default/pages/storefront/tests/Home.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import StoreContext from '~/contexts/storeContext'
+import Home from '~/themes/default/pages/storefront/Home'
+import { CategoryItem, ProductPublicInfo, StoreSettings } from '~/types'
+import * as mocks from '~/utils/mocks'
+
+describe('Home page component', () => {
+  test('Testing Home page component rendering', async () => {
+    const mockCategories: CategoryItem[] = (
+      (await mocks.getCategories()) as CategoryItem[]
+    ).map((item) => {
+      return {
+        id: item.id,
+        name: item.name,
+        slug: item.slug,
+        parentId: null,
+      }
+    })
+
+    render(
+      <StoreContext.Provider
+        value={{
+          storeSettings: (await mocks.getStoreInfo()) as StoreSettings,
+          categories: mockCategories,
+          publicPages: [],
+        }}
+      >
+        <Home
+          products={(await mocks.getMockProducts()) as ProductPublicInfo[]}
+        />
+      </StoreContext.Provider>,
+      { wrapper: MemoryRouter },
+    )
+
+    expect(
+      screen.getByText('Denim Deluxe Jeans - Classic Indigo'),
+    ).toBeDefined()
+  })
+})

--- a/app/utils/mocks.ts
+++ b/app/utils/mocks.ts
@@ -61,7 +61,7 @@ export function getStoreInfo(): Promise<object> {
       logo: settings.logo,
       description: settings.description,
       currency: settings.currency,
-      copyright: settings.copyright,
+      other: { copyright: settings.other.copyright },
     }),
   )
 }

--- a/mockdata/site_settings.json
+++ b/mockdata/site_settings.json
@@ -41,5 +41,5 @@
       "order": 6
     }
   ],
-  "copyright": "© Cachaca 2024"
+  "other": { "copyright": "© Cachaca 2024" }
 }


### PR DESCRIPTION
To fix the bug caused by empty banner object like below:

![image](https://github.com/user-attachments/assets/8fd655b1-71e7-49a1-9d24-4ac54b068833)

The issue is because we assumed the banners object is always a non-null value and we didn't do the null check in the Settings.tsx component.

Adding a default initial value for banners object while store installation will eliminate this issue.
